### PR TITLE
Fix some false statements

### DIFF
--- a/benchmark/benchmark_to_publish/formal/Dummit-Foote.lean
+++ b/benchmark/benchmark_to_publish/formal/Dummit-Foote.lean
@@ -46,7 +46,7 @@ sorry
 
 theorem exercise_1_1_17 {G : Type*} [group G] {x : G} {n : ℕ}
   (hxn: order_of x = n) :
-  x⁻¹ = x ^ (n-1) :=
+  x⁻¹ = x ^ (n - 1 : ℤ) :=
 sorry 
 
 theorem exercise_1_1_18 {G : Type*} [group G]
@@ -412,7 +412,7 @@ sorry
 
 theorem exercise_9_4_2d {p : ℕ} (hp : p.prime ∧ p > 2) 
   {f : polynomial ℤ} (hf : f = (X + 2)^p): 
-  irreducible (∑ n in (f.support - {0}), (f.coeff n) * X ^ (n-1) : 
+  irreducible (∑ n in (f.support \ {0}), (f.coeff n) * X ^ (n-1) : 
   polynomial ℤ) :=
 sorry 
 

--- a/benchmark/benchmark_to_publish/formal/Herstein.lean
+++ b/benchmark/benchmark_to_publish/formal/Herstein.lean
@@ -86,7 +86,7 @@ sorry
 
 theorem exercise_2_5_52 {G : Type*} [group G] [fintype G]
   (φ : G ≃* G) {I : finset G} (hI : ∀ x ∈ I, φ x = x⁻¹)
-  (hI1 : 0.75 * card G ≤ card I) : 
+  (hI1 : (0.75 : ℚ) * card G ≤ card I) : 
   ∀ x : G, φ x = x⁻¹ ∧ ∀ x y : G, x*y = y*x :=
 sorry
 
@@ -160,7 +160,7 @@ theorem exercise_4_2_6 {R : Type*} [ring R] (a x : R)
 sorry
 
 theorem exercise_4_2_9 {p : ℕ} (hp : nat.prime p) (hp1 : odd p) :
-  ∃ (a b : ℤ), a / b = ∑ i in finset.range p, 1 / (i + 1) → ↑p ∣ a :=
+  ∃ (a b : ℤ), (a / b : ℚ) = ∑ i in finset.range p, 1 / (i + 1) → ↑p ∣ a :=
 sorry
 
 theorem exercise_4_3_1 {R : Type*} [comm_ring R] (a : R) :


### PR DESCRIPTION
These fell afoul of division on naturals and integers meaning the wrong thing. Found by using `local attribute [-instance] nat.has_div int.has_div nat.has_sub` and inspecting what breaks.

There was also a use of pointwise subtraction where set subtraction was intended.